### PR TITLE
fix #2 : Now we can build this on windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
+ifeq ($(OS),Windows_NT)
+    SHELL := cmd.exe
+    .SHELLFLAGS := /C
+    BUILD = cmd /C "set GOOS=js&& set GOARCH=wasm&& go build -o server/main.wasm main.go"
+else
+    SHELL := /bin/sh
+    BUILD = GOOS=js GOARCH=wasm go build -o server/main.wasm main.go
+endif
+
 all: build
 
 build:
-	GOARCH=wasm GOOS=js go build -o server/main.wasm main.go
+	$(BUILD)
 
 serve:
 	go run server/server.go
+


### PR DESCRIPTION
The command for `make build` was good for *nix systems but a no go for Windows.

### Summary

project was not building on Windows. look at #issue-2

### Checklist
- [ x] `go fmt ./...`
- [x ] `go vet ./...`
- [x ] `make build` succeeds
- [x ] Docs updated (README/CHANGELOG) if needed


